### PR TITLE
#19 - status field missing - add field String status in GoogleResponse.

### DIFF
--- a/src/main/java/com/javafee/java/lessons/tasks/task2googleapi/service/dto/googlelocationpath/GoogleResponse.java
+++ b/src/main/java/com/javafee/java/lessons/tasks/task2googleapi/service/dto/googlelocationpath/GoogleResponse.java
@@ -8,5 +8,6 @@ import java.util.List;
 public class GoogleResponse {
 
     private List<Result> results;
+    private String status;
 
 }


### PR DESCRIPTION
Field String status added into GoogleResponse for better exception handling from Google API